### PR TITLE
Many code changes, mostly involving marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This mod adds a small number of curios, with a primary focus on scaling the player with Pehkui.
 
-This is the **1.19.2** branch. Currently, this branch's release version is **1.1.4**.
+This is the **1.19.2** branch. Currently, this branch's release version is **1.2.0**.
 
 The CurseForge page for this mod can be found [here](https://www.curseforge.com/minecraft/mc-mods/band-of-gigantism). 
 Additionally, the Modrinth page can be found [here](https://modrinth.com/mod/bog).

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
         classpath 'gradle.plugin.com.matthewprenger:CurseGradle:1.4.0'
-        classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7-1.0.0-SNAPSHOT'
+        classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7-SNAPSHOT'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     annotationProcessor 'org.ow2.asm:asm-commons:7.2'
     annotationProcessor 'org.ow2.asm:asm-util:7.2'
 
-    compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${version_curios}")
-    compileOnly fg.deobf("com.github.Virtuoel:Pehkui:${version_pehkui}")
+    implementation fg.deobf("top.theillusivec4.curios:curios-forge:${version_curios}")
+    implementation fg.deobf("com.github.Virtuoel:Pehkui:${version_pehkui}")
     minecraft "net.minecraftforge:forge:${version_forge}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,11 +76,14 @@ minecraft {
         client {
             properties 'org.gradle.jvmargs': '-Xms4G -Xmx4G'
             properties 'fml.earlyprogresswindow': 'false'
-            properties 'mixin.env.disableRefMap': 'true'
+            //properties 'mixin.env.disableRefMap': 'true'
             workingDirectory project.file('run')
 
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
+
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 
             mods {
                 band_of_gigantism {
@@ -95,6 +98,9 @@ minecraft {
 
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
+
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 
             mods {
                 band_of_gigantism {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=false
 version_mc=1.19.2
 version_forge=1.19.2-43.1.7
 version_mcp=2022.11.06-1.19.2
-version_pehkui=3.6.0-1.19.2-forge
+version_pehkui=3.7.11-1.19.2-forge
 version_curios=1.19.2-5.1.1.0
 
 # Mod

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ version_pehkui=3.7.11-1.19.2-forge
 version_curios=1.19.2-5.1.1.0
 
 # Mod
-mod_version=1.19.2-1.1.4
+mod_version=1.19.2-1.2.0
 mod_group=net.textstack.band_of_gigantism
 mod_archives_name=band_of_gigantism

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/textstack/band_of_gigantism/event/EventHandlerMyBallsInYourMouth.java
+++ b/src/main/java/net/textstack/band_of_gigantism/event/EventHandlerMyBallsInYourMouth.java
@@ -95,7 +95,7 @@ public class EventHandlerMyBallsInYourMouth {
             int strangeKills = tag.getInt("strangeKills");
             tooltip.add(Component.translatable(LoreStatHelper.displayStrangeName(strangeKills,LoreStatHelper.StrangeType.TOOLTIP))
                     .append(stack.getHoverName().copy().withStyle(ChatFormatting.DARK_GRAY))
-                    .append(Component.translatable("tooltip.band_of_gigantism.tooltip_strange_generic", "\u00A78" + strangeKills)));
+                    .append(Component.translatable("tooltip.band_of_gigantism.tooltip_strange_generic", "§8" + strangeKills)));
         }
     }
 
@@ -196,9 +196,9 @@ public class EventHandlerMyBallsInYourMouth {
                         event.getSource() != ModDamageSources.BOG_OBLITERATED &&
                         event.getSource() != ModDamageSources.BOG_PURIFIED &&
                         event.getSource() != ModDamageSources.BOG_UNKNOWN)
-                if ((event.getAmount() > c.recovery_minimum_damage.get()) && (Math.random() < c.recovery_chance.get())) {
-                    living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.recovery_duration.get(), 0, false, c.recovery_show_particles.get()));
-                }
+                    if ((event.getAmount() > c.recovery_minimum_damage.get()) && (Math.random() < c.recovery_chance.get())) {
+                        living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.recovery_duration.get(), 0, false, c.recovery_show_particles.get()));
+                    }
             }
 
             //for the strains of ascent effect to deal damage as fast as it wants
@@ -324,19 +324,19 @@ public class EventHandlerMyBallsInYourMouth {
     private String colorMark(LivingEntity living, String message) {
         String newMessage = null;
         if (CurioHelper.hasCurio(living, ModItems.MARK_OBLITERATED.get())) { //sorted in order of (in my opinion) difficulty
-            newMessage = "\u00A74" + message + "\u00A7r";
+            newMessage = "§4" + message + "§r";
         } else if (CurioHelper.hasCurio(living, ModItems.MARK_FADED.get())) {
-            newMessage = "\u00A78" + message + "\u00A7r";
+            newMessage = "§8" + message + "§r";
         } else if (CurioHelper.hasCurio(living, ModItems.MARK_JUDGED.get())) {
-            newMessage = "\u00A7c" + message + "\u00A7r";
+            newMessage = "§c" + message + "§r";
         } else if (CurioHelper.hasCurio(living, ModItems.MARK_DESCENDED.get())) {
-            newMessage = "\u00A79" + message + "\u00A7r";
+            newMessage = "§9" + message + "§r";
         } else if (CurioHelper.hasCurio(living, ModItems.MARK_UNKNOWN.get())) {
-            newMessage = "\u00A7a" + message + "\u00A7r";
+            newMessage = "§a" + message + "§r";
         } else if (CurioHelper.hasCurio(living, ModItems.MARK_FORGOTTEN.get())) {
-            newMessage = "\u00A76" + message + "\u00A7r";
+            newMessage = "§6" + message + "§r";
         } else if (CurioHelper.hasCurio(living, ModItems.MARK_PURIFIED.get())) {
-            newMessage = "\u00A77" + message + "\u00A7r";
+            newMessage = "§7" + message + "§r";
         }
         return newMessage;
     }

--- a/src/main/java/net/textstack/band_of_gigantism/event/EventHandlerMyBallsInYourMouth.java
+++ b/src/main/java/net/textstack/band_of_gigantism/event/EventHandlerMyBallsInYourMouth.java
@@ -37,9 +37,11 @@ import net.minecraftforge.fml.common.Mod;
 import net.textstack.band_of_gigantism.BandOfGigantism;
 import net.textstack.band_of_gigantism.config.BOGConfig;
 import net.textstack.band_of_gigantism.item.MarkUnknown;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.*;
 import net.textstack.band_of_gigantism.util.CurioHelper;
 import net.textstack.band_of_gigantism.util.LoreStatHelper;
+import net.textstack.band_of_gigantism.util.MarkHelper;
 
 import java.util.List;
 import java.util.Objects;
@@ -301,20 +303,12 @@ public class EventHandlerMyBallsInYourMouth {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void serverChat(ServerChatEvent event) {
-
         if (c.marks_color_chat.get()) {
             //append §[val] to the beginning of messages for marked players
-            String message = event.getRawText();
             LivingEntity living = event.getPlayer();
-            message = colorMark(living, message);
+            String message = colorMark(living, event.getRawText());
 
-            //insert colored text if required
-            Component newComponent;
-            if (message != null) {
-                newComponent = Component.literal(message);
-            } else {
-                newComponent = event.getMessage();
-            }
+            Component newComponent = Component.literal(message);
 
             event.setMessage(newComponent);
         }
@@ -322,23 +316,12 @@ public class EventHandlerMyBallsInYourMouth {
 
     //applies color to a message based on their mark
     private String colorMark(LivingEntity living, String message) {
-        String newMessage = null;
-        if (CurioHelper.hasCurio(living, ModItems.MARK_OBLITERATED.get())) { //sorted in order of (in my opinion) difficulty
-            newMessage = "§4" + message + "§r";
-        } else if (CurioHelper.hasCurio(living, ModItems.MARK_FADED.get())) {
-            newMessage = "§8" + message + "§r";
-        } else if (CurioHelper.hasCurio(living, ModItems.MARK_JUDGED.get())) {
-            newMessage = "§c" + message + "§r";
-        } else if (CurioHelper.hasCurio(living, ModItems.MARK_DESCENDED.get())) {
-            newMessage = "§9" + message + "§r";
-        } else if (CurioHelper.hasCurio(living, ModItems.MARK_UNKNOWN.get())) {
-            newMessage = "§a" + message + "§r";
-        } else if (CurioHelper.hasCurio(living, ModItems.MARK_FORGOTTEN.get())) {
-            newMessage = "§6" + message + "§r";
-        } else if (CurioHelper.hasCurio(living, ModItems.MARK_PURIFIED.get())) {
-            newMessage = "§7" + message + "§r";
+        for (MarkItem markItem : MarkHelper.getMarks()) {
+            if (CurioHelper.hasCurio(living, markItem) && markItem.getChatFormatting() != null) {
+                return markItem.getChatFormatting() + message + "§r";
+            }
         }
-        return newMessage;
+        return message;
     }
 
     @SubscribeEvent

--- a/src/main/java/net/textstack/band_of_gigantism/item/FalseHand.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/FalseHand.java
@@ -69,13 +69,13 @@ public class FalseHand extends Item implements ICurioItem {
                 int storedTime = stack.getOrCreateTag().getInt("timeLeft");
                 if (storedTime >= 60) {
                     int displayTime = 1 + storedTime / 60;
-                    tooltip.add(Component.translatable("tooltip.band_of_gigantism.false_hand_description_shift_0_minutes", "\u00A76" + displayTime));
+                    tooltip.add(Component.translatable("tooltip.band_of_gigantism.false_hand_description_shift_0_minutes", "§6" + displayTime));
                 } else {
                     if (storedTime == 0) {
                         tooltip.add(Component.translatable("tooltip.band_of_gigantism.false_hand_description_shift_0_second"));
                     } else {
                         int displayTime = 1 + storedTime;
-                        tooltip.add(Component.translatable("tooltip.band_of_gigantism.false_hand_description_shift_0_seconds", "\u00A76" + displayTime));
+                        tooltip.add(Component.translatable("tooltip.band_of_gigantism.false_hand_description_shift_0_seconds", "§6" + displayTime));
                     }
                 }
             }

--- a/src/main/java/net/textstack/band_of_gigantism/item/GoldenFryingPan.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/GoldenFryingPan.java
@@ -31,7 +31,7 @@ public class GoldenFryingPan extends SwordItem {
 
         int strangeKills = getStrangeKills(stack);
         tooltip.add(Component.translatable(LoreStatHelper.displayStrangeName(strangeKills,LoreStatHelper.StrangeType.TOOLTIP))
-                .append(Component.translatable("tooltip.band_of_gigantism.golden_frying_pan_description_flavor", "\u00A78" + strangeKills)));
+                .append(Component.translatable("tooltip.band_of_gigantism.golden_frying_pan_description_flavor", "§8" + strangeKills)));
         tooltip.add(Component.translatable("tooltip.band_of_gigantism.golden_frying_pan_description_0"));
         tooltip.add(Component.translatable("tooltip.band_of_gigantism.golden_frying_pan_description_1"));
         tooltip.add(Component.translatable("tooltip.band_of_gigantism.golden_frying_pan_description_2"));

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkDescended.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkDescended.java
@@ -38,7 +38,7 @@ public class MarkDescended extends MarkItem {
         LivingEntity living = slotContext.entity();
 
         //either lower the stored position (if the player is lower) or inflict strains of ascent (if player is >5 blocks higher)
-        int posY = (int) Math.ceil(living.blockPosition().getY());
+        int posY = living.blockPosition().getY();
         if (stack.getTag() != null) {
             int prevPosY = this.getPosY(stack);
 
@@ -71,7 +71,7 @@ public class MarkDescended extends MarkItem {
         //update mark's pos when not equipped
         LivingEntity living = (LivingEntity) entityIn;
         if (worldIn.getGameTime() % 10 == 0 && !CurioHelper.hasCurio(living, ModItems.MARK_DESCENDED.get())) {
-            int posY = (int) Math.ceil(living.blockPosition().getY());
+            int posY = living.blockPosition().getY();
             this.setPosY(stack, posY);
         }
     }

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkDescended.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkDescended.java
@@ -2,6 +2,7 @@ package net.textstack.band_of_gigantism.item;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -30,7 +31,7 @@ import java.util.UUID;
 public class MarkDescended extends MarkItem {
 
     public MarkDescended(Properties properties) {
-        super(properties, ModDamageSources.BOG_DESCENDED);
+        super(properties, ModDamageSources.BOG_DESCENDED, ChatFormatting.BLUE);
     }
 
     @Override

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkDescended.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkDescended.java
@@ -4,19 +4,17 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.textstack.band_of_gigantism.BandOfGigantism;
-import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.ModDamageSources;
 import net.textstack.band_of_gigantism.registry.ModEffects;
 import net.textstack.band_of_gigantism.registry.ModItems;
@@ -24,43 +22,19 @@ import net.textstack.band_of_gigantism.util.CurioHelper;
 import net.textstack.band_of_gigantism.util.LoreStatHelper;
 import org.jetbrains.annotations.NotNull;
 import top.theillusivec4.curios.api.SlotContext;
-import top.theillusivec4.curios.api.type.capability.ICurio;
-import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class MarkDescended extends Item implements ICurioItem {
-
-    final BOGConfig c = BOGConfig.INSTANCE;
+public class MarkDescended extends MarkItem {
 
     public MarkDescended(Properties properties) {
-        super(properties);
-    }
-
-    @Override
-    public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
-        ICurioItem.super.onUnequip(slotContext, newStack, stack);
-
-        //deal near-mortal damage, prevent healing
-        LivingEntity living = slotContext.entity();
-        if (!CurioHelper.hasCurio(living, ModItems.MARK_DESCENDED.get())) { //this method is called whenever nbt changes, make sure not to kill for that
-            living.hurt(ModDamageSources.BOG_DESCENDED, living.getMaxHealth() - 1);
-            living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.marks_duration.get(), 0, false, false));
-        }
-    }
-
-    @Override
-    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
-        return ICurioItem.super.canEquip(slotContext, stack) && !CurioHelper.hasCurio(slotContext.entity(), ModItems.MARK_DESCENDED.get());
+        super(properties, ModDamageSources.BOG_DESCENDED);
     }
 
     @Override
     public void curioTick(SlotContext slotContext, ItemStack stack) {
-        ICurioItem.super.curioTick(slotContext, stack);
-
         LivingEntity living = slotContext.entity();
 
         //either lower the stored position (if the player is lower) or inflict strains of ascent (if player is >5 blocks higher)
@@ -133,22 +107,6 @@ public class MarkDescended extends Item implements ICurioItem {
                 BandOfGigantism.MODID + ":armor_modifier_descended", c.mark_descended_armor.get(), AttributeModifier.Operation.ADDITION));
 
         return attributesDefault;
-    }
-
-    @NotNull
-    @Override
-    public ICurio.DropRule getDropRule(SlotContext slotContext, DamageSource source, int lootingLevel, boolean recentlyHit, ItemStack stack) {
-        return ICurio.DropRule.ALWAYS_KEEP;
-    }
-
-    @Override
-    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
-        return true;
-    }
-
-    @Override
-    public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
-        return new ArrayList<>();
     }
 
     //get posy tag

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkFaded.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkFaded.java
@@ -4,54 +4,27 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.textstack.band_of_gigantism.BandOfGigantism;
-import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.ModDamageSources;
-import net.textstack.band_of_gigantism.registry.ModEffects;
-import net.textstack.band_of_gigantism.registry.ModItems;
-import net.textstack.band_of_gigantism.util.CurioHelper;
 import net.textstack.band_of_gigantism.util.LoreStatHelper;
 import org.jetbrains.annotations.NotNull;
 import top.theillusivec4.curios.api.SlotContext;
-import top.theillusivec4.curios.api.type.capability.ICurio;
-import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class MarkFaded extends Item implements ICurioItem {
-
-    final BOGConfig c = BOGConfig.INSTANCE;
+public class MarkFaded extends MarkItem {
 
     public MarkFaded(Properties properties) {
-        super(properties);
-    }
-
-    @Override
-    public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
-        ICurioItem.super.onUnequip(slotContext, newStack, stack);
-
-        //deal near-mortal damage, prevent healing
-        LivingEntity living = slotContext.entity();
-        living.hurt(ModDamageSources.BOG_FADED, living.getMaxHealth() - 1);
-        living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.marks_duration.get(), 0, false, false));
-    }
-
-    @Override
-    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
-        return ICurioItem.super.canEquip(slotContext, stack) && !CurioHelper.hasCurio(slotContext.entity(), ModItems.MARK_FADED.get());
+        super(properties, ModDamageSources.BOG_FADED);
     }
 
     @Override
@@ -85,21 +58,5 @@ public class MarkFaded extends Item implements ICurioItem {
                 BandOfGigantism.MODID + ":attack_damage_modifier_faded", c.mark_faded_damage.get(), AttributeModifier.Operation.MULTIPLY_BASE));
 
         return attributesDefault;
-    }
-
-    @NotNull
-    @Override
-    public ICurio.DropRule getDropRule(SlotContext slotContext, DamageSource source, int lootingLevel, boolean recentlyHit, ItemStack stack) {
-        return ICurio.DropRule.ALWAYS_KEEP;
-    }
-
-    @Override
-    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
-        return true;
-    }
-
-    @Override
-    public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
-        return new ArrayList<>();
     }
 }

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkFaded.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkFaded.java
@@ -2,6 +2,7 @@ package net.textstack.band_of_gigantism.item;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.ai.attributes.Attribute;
@@ -24,7 +25,7 @@ import java.util.UUID;
 public class MarkFaded extends MarkItem {
 
     public MarkFaded(Properties properties) {
-        super(properties, ModDamageSources.BOG_FADED);
+        super(properties, ModDamageSources.BOG_FADED, ChatFormatting.DARK_GRAY);
     }
 
     @Override

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkForgotten.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkForgotten.java
@@ -1,5 +1,6 @@
 package net.textstack.band_of_gigantism.item;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
@@ -16,7 +17,7 @@ import java.util.List;
 public class MarkForgotten extends MarkItem {
 
     public MarkForgotten(Properties properties) {
-        super(properties, ModDamageSources.BOG_FORGOTTEN);
+        super(properties, ModDamageSources.BOG_FORGOTTEN, ChatFormatting.GOLD);
     }
 
     @Override

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkForgotten.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkForgotten.java
@@ -2,49 +2,21 @@ package net.textstack.band_of_gigantism.item;
 
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
-import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.ModDamageSources;
-import net.textstack.band_of_gigantism.registry.ModEffects;
-import net.textstack.band_of_gigantism.registry.ModItems;
-import net.textstack.band_of_gigantism.util.CurioHelper;
 import net.textstack.band_of_gigantism.util.LoreStatHelper;
 import org.jetbrains.annotations.NotNull;
-import top.theillusivec4.curios.api.SlotContext;
-import top.theillusivec4.curios.api.type.capability.ICurio;
-import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 
-public class MarkForgotten extends Item implements ICurioItem {
-
-    final BOGConfig c = BOGConfig.INSTANCE;
+public class MarkForgotten extends MarkItem {
 
     public MarkForgotten(Properties properties) {
-        super(properties);
-    }
-
-    @Override
-    public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
-        ICurioItem.super.onUnequip(slotContext, newStack, stack);
-
-        //deal near-mortal damage, prevent healing for 10 seconds
-        LivingEntity living = slotContext.entity();
-        living.hurt(ModDamageSources.BOG_FORGOTTEN, living.getMaxHealth() - 1);
-        living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.marks_duration.get(), 0, false, false));
-    }
-
-    @Override
-    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
-        return ICurioItem.super.canEquip(slotContext, stack) && !CurioHelper.hasCurio(slotContext.entity(), ModItems.MARK_FORGOTTEN.get());
+        super(properties, ModDamageSources.BOG_FORGOTTEN);
     }
 
     @Override
@@ -67,21 +39,5 @@ public class MarkForgotten extends Item implements ICurioItem {
         } else {
             tooltip.add(Component.translatable("tooltip.band_of_gigantism.shift"));
         }
-    }
-
-    @NotNull
-    @Override
-    public ICurio.DropRule getDropRule(SlotContext slotContext, DamageSource source, int lootingLevel, boolean recentlyHit, ItemStack stack) {
-        return ICurio.DropRule.ALWAYS_KEEP;
-    }
-
-    @Override
-    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
-        return true;
-    }
-
-    @Override
-    public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
-        return new ArrayList<>();
     }
 }

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkJudged.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkJudged.java
@@ -4,55 +4,27 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.textstack.band_of_gigantism.BandOfGigantism;
-import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.ModDamageSources;
-import net.textstack.band_of_gigantism.registry.ModEffects;
-import net.textstack.band_of_gigantism.registry.ModItems;
-import net.textstack.band_of_gigantism.util.CurioHelper;
 import net.textstack.band_of_gigantism.util.LoreStatHelper;
 import org.jetbrains.annotations.NotNull;
 import top.theillusivec4.curios.api.SlotContext;
-import top.theillusivec4.curios.api.type.capability.ICurio;
-import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class MarkJudged extends Item implements ICurioItem {
-
-    final BOGConfig c = BOGConfig.INSTANCE;
+public class MarkJudged extends MarkItem {
 
     public MarkJudged(Properties properties) {
-        super(properties);
-    }
-
-    @Override
-    public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
-        ICurioItem.super.onUnequip(slotContext, newStack, stack);
-
-        LivingEntity living = slotContext.entity();
-
-        //deal near-mortal damage, prevent healing for 10 seconds
-        living.hurt(ModDamageSources.BOG_JUDGED, living.getMaxHealth() - 1);
-        living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.marks_duration.get(), 0, false, false));
-    }
-
-    @Override
-    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
-        return ICurioItem.super.canEquip(slotContext, stack) && !CurioHelper.hasCurio(slotContext.entity(), ModItems.MARK_JUDGED.get());
+        super(properties, ModDamageSources.BOG_JUDGED);
     }
 
     @Override
@@ -87,21 +59,5 @@ public class MarkJudged extends Item implements ICurioItem {
                 BandOfGigantism.MODID + ":attack_attack_knockback_modifier_obl", c.mark_judged_speed.get(), AttributeModifier.Operation.MULTIPLY_BASE));
 
         return attributesDefault;
-    }
-
-    @NotNull
-    @Override
-    public ICurio.DropRule getDropRule(SlotContext slotContext, DamageSource source, int lootingLevel, boolean recentlyHit, ItemStack stack) {
-        return ICurio.DropRule.ALWAYS_KEEP;
-    }
-
-    @Override
-    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
-        return true;
-    }
-
-    @Override
-    public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
-        return new ArrayList<>();
     }
 }

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkJudged.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkJudged.java
@@ -2,6 +2,7 @@ package net.textstack.band_of_gigantism.item;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.ai.attributes.Attribute;
@@ -24,7 +25,7 @@ import java.util.UUID;
 public class MarkJudged extends MarkItem {
 
     public MarkJudged(Properties properties) {
-        super(properties, ModDamageSources.BOG_JUDGED);
+        super(properties, ModDamageSources.BOG_JUDGED, ChatFormatting.RED);
     }
 
     @Override

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkObliterated.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkObliterated.java
@@ -10,12 +10,11 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.textstack.band_of_gigantism.BandOfGigantism;
-import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.ModDamageSources;
 import net.textstack.band_of_gigantism.registry.ModEffects;
 import net.textstack.band_of_gigantism.registry.ModItems;
@@ -24,25 +23,19 @@ import net.textstack.band_of_gigantism.util.LoreStatHelper;
 import org.jetbrains.annotations.NotNull;
 import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.type.capability.ICurio;
-import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class MarkObliterated extends Item implements ICurioItem {
-
-    final BOGConfig c = BOGConfig.INSTANCE;
+public class MarkObliterated extends MarkItem {
 
     public MarkObliterated(Properties properties) {
-        super(properties);
+        super(properties, null);
     }
 
     @Override
     public void onEquip(SlotContext slotContext, ItemStack prevStack, ItemStack stack) {
-        ICurioItem.super.onEquip(slotContext, prevStack, stack);
-
         //check if already equipped
         if (slotContext.entity() instanceof ServerPlayer player) {
             if (player.getPersistentData().getBoolean("obliteratedEquip")) {
@@ -61,8 +54,6 @@ public class MarkObliterated extends Item implements ICurioItem {
 
     @Override
     public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
-        ICurioItem.super.onUnequip(slotContext, newStack, stack);
-
         if (slotContext.entity() instanceof ServerPlayer player) {
             if (!CurioHelper.hasCurio(player, ModItems.MARK_OBLITERATED.get())) {
                 player.getPersistentData().putBoolean("obliteratedEquip", false);
@@ -70,11 +61,6 @@ public class MarkObliterated extends Item implements ICurioItem {
                 player.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.marks_duration.get(), 0, false, false));
             }
         }
-    }
-
-    @Override
-    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
-        return ICurioItem.super.canEquip(slotContext, stack) && !CurioHelper.hasCurio(slotContext.entity(), ModItems.MARK_OBLITERATED.get());
     }
 
     @Override
@@ -123,15 +109,5 @@ public class MarkObliterated extends Item implements ICurioItem {
     @Override
     public ICurio.DropRule getDropRule(SlotContext slotContext, DamageSource source, int lootingLevel, boolean recentlyHit, ItemStack stack) {
         return ICurio.DropRule.ALWAYS_DROP;
-    }
-
-    @Override
-    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
-        return true;
-    }
-
-    @Override
-    public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
-        return new ArrayList<>();
     }
 }

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkObliterated.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkObliterated.java
@@ -2,6 +2,7 @@ package net.textstack.band_of_gigantism.item;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
@@ -31,7 +32,7 @@ import java.util.UUID;
 public class MarkObliterated extends MarkItem {
 
     public MarkObliterated(Properties properties) {
-        super(properties, null);
+        super(properties, null, ChatFormatting.DARK_RED);
     }
 
     @Override

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkPurified.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkPurified.java
@@ -2,6 +2,7 @@ package net.textstack.band_of_gigantism.item;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.LivingEntity;
@@ -29,7 +30,7 @@ public class MarkPurified extends MarkItem {
     final BOGConfig c = BOGConfig.INSTANCE;
 
     public MarkPurified(Properties properties) {
-        super(properties, ModDamageSources.BOG_PURIFIED);
+        super(properties, ModDamageSources.BOG_PURIFIED, ChatFormatting.GRAY);
     }
 
     @Override

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkPurified.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkPurified.java
@@ -4,51 +4,39 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.textstack.band_of_gigantism.BandOfGigantism;
 import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.ModDamageSources;
-import net.textstack.band_of_gigantism.registry.ModEffects;
-import net.textstack.band_of_gigantism.registry.ModItems;
-import net.textstack.band_of_gigantism.util.CurioHelper;
 import org.jetbrains.annotations.NotNull;
 import top.theillusivec4.curios.api.SlotContext;
-import top.theillusivec4.curios.api.type.capability.ICurio;
-import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class MarkPurified extends Item implements ICurioItem {
+public class MarkPurified extends MarkItem {
 
     final BOGConfig c = BOGConfig.INSTANCE;
 
     public MarkPurified(Properties properties) {
-        super(properties);
+        super(properties, ModDamageSources.BOG_PURIFIED);
     }
 
     @Override
     public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
-        ICurioItem.super.onUnequip(slotContext, newStack, stack);
+        super.onUnequip(slotContext, newStack, stack);
 
         LivingEntity living = slotContext.entity();
-
-        //deal near-mortal damage, prevent healing for 10 seconds
-        living.hurt(ModDamageSources.BOG_PURIFIED, living.getMaxHealth() - 1);
-        living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.marks_duration.get(), 0, false, false));
 
         //remove the variable modifiers
         AttributeMap map = living.getAttributes();
@@ -56,14 +44,7 @@ public class MarkPurified extends Item implements ICurioItem {
     }
 
     @Override
-    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
-        return ICurioItem.super.canEquip(slotContext, stack) && !CurioHelper.hasCurio(slotContext.entity(), ModItems.MARK_PURIFIED.get());
-    }
-
-    @Override
     public void curioTick(SlotContext slotContext, ItemStack stack) {
-        ICurioItem.super.curioTick(slotContext, stack);
-
         LivingEntity living = slotContext.entity();
 
         //reapply modifiers
@@ -92,22 +73,6 @@ public class MarkPurified extends Item implements ICurioItem {
         } else {
             tooltip.add(Component.translatable("tooltip.band_of_gigantism.shift"));
         }
-    }
-
-    @NotNull
-    @Override
-    public ICurio.DropRule getDropRule(SlotContext slotContext, DamageSource source, int lootingLevel, boolean recentlyHit, ItemStack stack) {
-        return ICurio.DropRule.ALWAYS_KEEP;
-    }
-
-    @Override
-    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
-        return true;
-    }
-
-    @Override
-    public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
-        return new ArrayList<>();
     }
 
     //variable modifiers, able to change as the user wears the curio

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkTrue.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkTrue.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.textstack.band_of_gigantism.config.BOGConfig;
 import net.textstack.band_of_gigantism.item.base.MarkItem;
-import net.textstack.band_of_gigantism.registry.ModItems;
 import net.textstack.band_of_gigantism.util.MarkHelper;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkTrue.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkTrue.java
@@ -50,22 +50,23 @@ public class MarkTrue extends Item {
         }
     }
 
+    private ItemStack selectRandomMark() {
+        List<MarkItem> marks = MarkHelper.getMarks();
+
+        int pick = (int) (Math.random() * marks.size());
+        return new ItemStack(marks.get(pick));
+    }
+
     @Override
     public void inventoryTick(@NotNull ItemStack stack, @NotNull Level worldIn, @NotNull Entity entityIn, int itemSlot, boolean isSelected) {
-        super.inventoryTick(stack, worldIn, entityIn, itemSlot, isSelected);
+        if (worldIn.isClientSide() || !(entityIn instanceof Player player)) return;
 
         //replaces the item with one of seven marks
-        if (entityIn instanceof Player player) {
+        if (player.isCreative() || !player.isAlive() || player.isSpectator()) return;
+        NonNullList<ItemStack> list = player.getInventory().items;
 
-            if (player.isCreative() || !player.isAlive() || player.isSpectator()) return;
-            NonNullList<ItemStack> list = player.getInventory().items;
+        ItemStack stackCheck = selectRandomMark();
 
-            List<MarkItem> marks = MarkHelper.getMarks();
-
-            int pick = (int) (Math.random() * marks.size());
-            ItemStack stackCheck = new ItemStack(marks.get(pick));
-
-            list.set(itemSlot, stackCheck);
-        }
+        list.set(itemSlot, stackCheck);
     }
 }

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkTrue.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkTrue.java
@@ -12,7 +12,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.ModItems;
+import net.textstack.band_of_gigantism.util.MarkHelper;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -43,7 +45,7 @@ public class MarkTrue extends Item {
             tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_true_description_flavor"));
             tooltip.add(Component.translatable("tooltip.band_of_gigantism.void"));
             tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_true_description_0"));
-            tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_true_description_1"));
+            tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_true_description_1", "§6" + MarkHelper.getMarks().size()));
         } else {
             tooltip.add(Component.translatable("tooltip.band_of_gigantism.shift"));
         }
@@ -59,17 +61,11 @@ public class MarkTrue extends Item {
             if (player.isCreative() || !player.isAlive() || player.isSpectator()) return;
             NonNullList<ItemStack> list = player.getInventory().items;
 
-            ItemStack stackCheck = stack;
-            int pick = (int) (Math.random() * 7);
-            switch (pick) {
-                case 0 -> stackCheck = new ItemStack(ModItems.MARK_FADED.get());
-                case 1 -> stackCheck = new ItemStack(ModItems.MARK_FORGOTTEN.get());
-                case 2 -> stackCheck = new ItemStack(ModItems.MARK_PURIFIED.get());
-                case 3 -> stackCheck = new ItemStack(ModItems.MARK_DESCENDED.get());
-                case 4 -> stackCheck = new ItemStack(ModItems.MARK_UNKNOWN.get());
-                case 5 -> stackCheck = new ItemStack(ModItems.MARK_JUDGED.get());
-                case 6 -> stackCheck = new ItemStack(ModItems.MARK_OBLITERATED.get());
-            }
+            List<MarkItem> marks = MarkHelper.getMarks();
+
+            int pick = (int) (Math.random() * marks.size());
+            ItemStack stackCheck = new ItemStack(marks.get(pick));
+
             list.set(itemSlot, stackCheck);
         }
     }

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkUnknown.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkUnknown.java
@@ -38,7 +38,7 @@ public class MarkUnknown extends MarkItem {
     final BOGConfig c = BOGConfig.INSTANCE;
 
     public MarkUnknown(Properties properties) {
-        super(properties, ModDamageSources.BOG_UNKNOWN);
+        super(properties, ModDamageSources.BOG_UNKNOWN, ChatFormatting.GREEN);
     }
 
     @Override

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkUnknown.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkUnknown.java
@@ -6,7 +6,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -17,61 +16,44 @@ import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.textstack.band_of_gigantism.BandOfGigantism;
 import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.item.base.MarkItem;
 import net.textstack.band_of_gigantism.registry.ModDamageSources;
-import net.textstack.band_of_gigantism.registry.ModEffects;
 import net.textstack.band_of_gigantism.registry.ModItems;
 import net.textstack.band_of_gigantism.util.CurioHelper;
 import net.textstack.band_of_gigantism.util.LoreStatHelper;
 import org.jetbrains.annotations.NotNull;
 import top.theillusivec4.curios.api.SlotContext;
-import top.theillusivec4.curios.api.type.capability.ICurio;
-import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class MarkUnknown extends Item implements ICurioItem {
+public class MarkUnknown extends MarkItem {
 
     final BOGConfig c = BOGConfig.INSTANCE;
 
     public MarkUnknown(Properties properties) {
-        super(properties);
+        super(properties, ModDamageSources.BOG_UNKNOWN);
     }
 
     @Override
     public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
-        ICurioItem.super.onUnequip(slotContext, newStack, stack);
+        super.onUnequip(slotContext, newStack, stack);
 
         LivingEntity living = slotContext.entity();
         if (!CurioHelper.hasCurio(living, ModItems.MARK_UNKNOWN.get())) {
-
-            //deal near-mortal damage, prevent healing for 10 seconds
-            living.hurt(ModDamageSources.BOG_UNKNOWN, living.getMaxHealth() - 1);
-            living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.marks_duration.get(), 0, false, false));
-
-            //remove the variable modifiers
             AttributeMap map = living.getAttributes();
             map.removeAttributeModifiers(this.createAttributeMap(stack));
         }
     }
 
     @Override
-    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
-        return ICurioItem.super.canEquip(slotContext, stack) && !CurioHelper.hasCurio(slotContext.entity(), ModItems.MARK_UNKNOWN.get());
-    }
-
-    @Override
     public void curioTick(SlotContext slotContext, ItemStack stack) {
-        ICurioItem.super.curioTick(slotContext, stack);
-
         LivingEntity living = slotContext.entity();
 
         if (living.level.getGameTime() % 20 == 0) {
@@ -218,22 +200,6 @@ public class MarkUnknown extends Item implements ICurioItem {
                 BandOfGigantism.MODID + ":luck_modifier_unknown", 1, AttributeModifier.Operation.MULTIPLY_BASE));
 
         return attributesDefault;
-    }
-
-    @NotNull
-    @Override
-    public ICurio.DropRule getDropRule(SlotContext slotContext, DamageSource source, int lootingLevel, boolean recentlyHit, ItemStack stack) {
-        return ICurio.DropRule.ALWAYS_KEEP;
-    }
-
-    @Override
-    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
-        return true;
-    }
-
-    @Override
-    public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
-        return new ArrayList<>();
     }
 
     //variable modifiers, able to change as the user wears the curio

--- a/src/main/java/net/textstack/band_of_gigantism/item/MarkUnknown.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/MarkUnknown.java
@@ -126,28 +126,28 @@ public class MarkUnknown extends MarkItem {
             //time
             if (storedTime >= 60) {
                 int displayTime = 1 + storedTime / 60;
-                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_0_minutes", "\u00A76" + displayTime));
+                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_0_minutes", "§6" + displayTime));
             } else {
                 if (storedTime == 0) {
                     tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_0_second"));
                 } else {
                     int displayTime = 1 + storedTime;
-                    tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_0_seconds", "\u00A76" + displayTime));
+                    tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_0_seconds", "§6" + displayTime));
                 }
             }
 
             //health
             if (randomAttributes[0] > 0) {
-                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_1_positive", "\u00A76" + randomAttributes[0]));
+                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_1_positive", "§6" + randomAttributes[0]));
             } else if (randomAttributes[0] < 0) {
-                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_1_negative", "\u00A76" + randomAttributes[0]));
+                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_1_negative", "§6" + randomAttributes[0]));
             }
 
             //speed
             if (randomAttributes[1] > 0) {
-                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_2_positive", "\u00A76" + randomAttributes[1] + "%"));
+                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_2_positive", "§6" + randomAttributes[1] + "%"));
             } else if (randomAttributes[1] < 0) {
-                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_2_negative", "\u00A76" + randomAttributes[1] + "%"));
+                tooltip.add(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_2_negative", "§6" + randomAttributes[1] + "%"));
             }
 
             //regen
@@ -179,8 +179,8 @@ public class MarkUnknown extends MarkItem {
             MutableComponent effectComponent = Component.translatable(effect).withStyle(ChatFormatting.GOLD);
 
             String amp = switch (randomEffects[1]) {
-                case 1 -> "\u00A76II ";
-                case 2 -> "\u00A76III ";
+                case 1 -> "§6II ";
+                case 2 -> "§6III ";
                 default -> "";
             };
             tooltip.add(effectComponent.append(Component.translatable("tooltip.band_of_gigantism.mark_unknown_description_shift_4", amp)));

--- a/src/main/java/net/textstack/band_of_gigantism/item/base/MarkItem.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/base/MarkItem.java
@@ -9,6 +9,7 @@ import net.minecraft.world.item.ItemStack;
 import net.textstack.band_of_gigantism.config.BOGConfig;
 import net.textstack.band_of_gigantism.registry.ModEffects;
 import net.textstack.band_of_gigantism.util.CurioHelper;
+import net.textstack.band_of_gigantism.util.MarkHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import top.theillusivec4.curios.api.SlotContext;
@@ -32,6 +33,8 @@ public class MarkItem extends Item implements ICurioItem {
         super(p_41383_);
 
         this.unequipDamageType = unequipDamageType;
+
+        MarkHelper.addMark(this);
     }
 
     @Override

--- a/src/main/java/net/textstack/band_of_gigantism/item/base/MarkItem.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/base/MarkItem.java
@@ -1,5 +1,6 @@
 package net.textstack.band_of_gigantism.item.base;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -25,14 +26,23 @@ public class MarkItem extends Item implements ICurioItem {
      * The DamageSource inflicted when the wearer unequips this mark. If this is null, the wearer will not take
      * damage when unequipping the mark.
      */
+    @Nullable
     private final DamageSource unequipDamageType;
+
+    /**
+     * The formatting code appended to the beginning of a player's chat message if they are wearing the mark.
+     * Order of priority is based on the order of registry.
+     */
+    @Nullable
+    private final ChatFormatting formatting;
 
     protected static final BOGConfig c = BOGConfig.INSTANCE; // this will be inherited by all marks
 
-    public MarkItem(Properties p_41383_, @Nullable DamageSource unequipDamageType) {
+    public MarkItem(Properties p_41383_, @Nullable DamageSource unequipDamageType, @Nullable ChatFormatting formatting) {
         super(p_41383_);
 
         this.unequipDamageType = unequipDamageType;
+        this.formatting = formatting;
 
         MarkHelper.addMark(this);
     }
@@ -68,5 +78,10 @@ public class MarkItem extends Item implements ICurioItem {
     @Override
     public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
         return new ArrayList<>();
+    }
+
+    @Nullable
+    public ChatFormatting getChatFormatting() {
+        return formatting;
     }
 }

--- a/src/main/java/net/textstack/band_of_gigantism/item/base/MarkItem.java
+++ b/src/main/java/net/textstack/band_of_gigantism/item/base/MarkItem.java
@@ -1,0 +1,69 @@
+package net.textstack.band_of_gigantism.item.base;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.textstack.band_of_gigantism.config.BOGConfig;
+import net.textstack.band_of_gigantism.registry.ModEffects;
+import net.textstack.band_of_gigantism.util.CurioHelper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import top.theillusivec4.curios.api.SlotContext;
+import top.theillusivec4.curios.api.type.capability.ICurio;
+import top.theillusivec4.curios.api.type.capability.ICurioItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MarkItem extends Item implements ICurioItem {
+
+    /**
+     * The DamageSource inflicted when the wearer unequips this mark. If this is null, the wearer will not take
+     * damage when unequipping the mark.
+     */
+    private final DamageSource unequipDamageType;
+
+    protected static final BOGConfig c = BOGConfig.INSTANCE; // this will be inherited by all marks
+
+    public MarkItem(Properties p_41383_, @Nullable DamageSource unequipDamageType) {
+        super(p_41383_);
+
+        this.unequipDamageType = unequipDamageType;
+    }
+
+    @Override
+    public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
+        if (unequipDamageType == null) return; // used for obliterated, which does not kill on unequip
+
+        //deal near-mortal damage, prevent healing
+        LivingEntity living = slotContext.entity();
+        if (!CurioHelper.hasCurio(living, this)) { //this method is called whenever nbt changes, make sure not to kill for that
+            living.hurt(unequipDamageType, living.getMaxHealth() - 1);
+            living.addEffect(new MobEffectInstance(ModEffects.RECOVERING.get(), c.marks_duration.get(), 0, false, false));
+        }
+    }
+
+    @Override
+    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
+        return !CurioHelper.hasCurio(slotContext.entity(), this);
+    }
+
+    @NotNull
+    @Override
+    public ICurio.DropRule getDropRule(SlotContext slotContext, DamageSource source, int lootingLevel, boolean recentlyHit, ItemStack stack) {
+        return ICurio.DropRule.ALWAYS_KEEP;
+    }
+
+    @Override
+    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
+        return true;
+    }
+
+    @Override
+    public List<Component> getAttributesTooltip(List<Component> tooltips, ItemStack stack) {
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/net/textstack/band_of_gigantism/mixin/MixinFoodStats.java
+++ b/src/main/java/net/textstack/band_of_gigantism/mixin/MixinFoodStats.java
@@ -23,8 +23,8 @@ public class MixinFoodStats {
         //prevents hunger-based regen from working, otherwise it would uselessly deplete itself
         if (CurioHelper.hasCurio(player, ModItems.MARK_FADED.get()) || Objects.requireNonNull(player).hasEffect(ModEffects.RECOVERING.get()) || CurioHelper.hasCurio(player, ModItems.BAND_CRUSTACEOUS.get())) {
             return false;
-        } else {
-            return player.level.getGameRules().getBoolean(key);
         }
+
+        return player.level.getGameRules().getBoolean(key);
     }
 }

--- a/src/main/java/net/textstack/band_of_gigantism/util/LoreStatHelper.java
+++ b/src/main/java/net/textstack/band_of_gigantism/util/LoreStatHelper.java
@@ -56,14 +56,14 @@ public class LoreStatHelper {
         String value;
         if (isPercent) {
             int display_percent = (int) (Math.abs(display) * 100);
-            value = "\u00A76" + display_percent + "%";
+            value = "§6" + display_percent + "%";
         } else {
             float display_out = Math.abs(display);
             if (display_out % 1 == 0) {
                 int display_out_solid = (int) display_out;
-                value = "\u00A76" + display_out_solid;
+                value = "§6" + display_out_solid;
             } else {
-                value = "\u00A76" + display_out;
+                value = "§6" + display_out;
             }
         }
 
@@ -86,9 +86,9 @@ public class LoreStatHelper {
         int display_percent = (int) (Math.abs(display - 1) * 100);
 
         if (display < 1) {
-            return Component.translatable("tooltip.band_of_gigantism.shrink_band_generic_description_percent", "\u00A76" + display_percent + "%");
+            return Component.translatable("tooltip.band_of_gigantism.shrink_band_generic_description_percent", "§6" + display_percent + "%");
         } else {
-            return Component.translatable("tooltip.band_of_gigantism.band_generic_description_percent", "\u00A76" + display_percent + "%");
+            return Component.translatable("tooltip.band_of_gigantism.band_generic_description_percent", "§6" + display_percent + "%");
         }
     }
 

--- a/src/main/java/net/textstack/band_of_gigantism/util/MarkHelper.java
+++ b/src/main/java/net/textstack/band_of_gigantism/util/MarkHelper.java
@@ -3,10 +3,11 @@ package net.textstack.band_of_gigantism.util;
 import net.textstack.band_of_gigantism.item.base.MarkItem;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class MarkHelper {
-    private static final List<MarkItem> marks = new ArrayList<>();
+    private static final List<MarkItem> marks = Collections.synchronizedList(new ArrayList<>());
 
 
     public static List<MarkItem> getMarks() {

--- a/src/main/java/net/textstack/band_of_gigantism/util/MarkHelper.java
+++ b/src/main/java/net/textstack/band_of_gigantism/util/MarkHelper.java
@@ -1,0 +1,19 @@
+package net.textstack.band_of_gigantism.util;
+
+import net.textstack.band_of_gigantism.item.base.MarkItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MarkHelper {
+    private static final List<MarkItem> marks = new ArrayList<>();
+
+
+    public static List<MarkItem> getMarks() {
+        return marks;
+    }
+
+    public static void addMark(MarkItem mark) {
+        marks.add(mark);
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@ loaderVersion="[41,)" #mandatory This is typically bumped every Minecraft versio
 license="MIT"
 [[mods]] #mandatory
 modId="band_of_gigantism" #mandatory
-version="1.19.2-1.1.4" #mandatory
+version="1.19.2-1.2.0" #mandatory
 displayName="Band of Gigantism" #mandatory
 logoFile="logo.png" #optional
 credits="Terraria's Calamity mod, for use of a single texture; Enigmatic Legacy for description style; several other mods for code reference" #optional

--- a/src/main/resources/assets/band_of_gigantism/lang/en_us.json
+++ b/src/main/resources/assets/band_of_gigantism/lang/en_us.json
@@ -82,7 +82,7 @@
   "tooltip.band_of_gigantism.error_negative": "§6-%1$s §4Invalid Stat",
 
 
-  "tooltip.band_of_gigantism.tooltip_strange_generic": "§8 - Kills: ",
+  "tooltip.band_of_gigantism.tooltip_strange_generic": "§8 - Kills: %1$s",
 
   "tooltip.band_of_gigantism.title_strange_0": "§6Strange ",
   "tooltip.band_of_gigantism.title_strange_10": "§6Unremarkable ",

--- a/src/main/resources/assets/band_of_gigantism/lang/en_us.json
+++ b/src/main/resources/assets/band_of_gigantism/lang/en_us.json
@@ -186,7 +186,7 @@
 
   "tooltip.band_of_gigantism.mark_true_description_flavor": "§r§oThat's how it is 'til the end.",
   "tooltip.band_of_gigantism.mark_true_description_0": "§5Upon contact with §6mortal hands§5, this artifact",
-  "tooltip.band_of_gigantism.mark_true_description_1": "§5will collapse into one of its §6seven counterparts§5.",
+  "tooltip.band_of_gigantism.mark_true_description_1": "§5will collapse into one of its %1$s §6counterparts§5.",
 
   "tooltip.band_of_gigantism.mark_obliterated_description_flavor": "§4§o...but it got a SLIGHT DENT in the back.",
   "tooltip.band_of_gigantism.mark_obliterated_description_0": "§6+100% §9Attack Damage",


### PR DESCRIPTION
I've been wanting to do this for a while, and I may or may not have overdone it. This is everything I changed:

Changes the following in the build.gradle and gradle.properties to make the mod less hellish to fork:
- Gradle was updated from 7.1.1 to 7.2. IntelliJ kept yelling at me about it.
- Pehkui was updated to 3.7.11-1.19.2-forge.
- Curios and Pehkui are now dependencies on both sides, instead of compileOnly.
- `properties 'mixin.env.disableRefMap': 'true'` was commented out. This broke Pehkui during runtime, and you do not realistically need to do this.

I genuinely do not know how you test your own mod, given some of the changes I had to make above.

Marks have been massively overhauled:
- All marks now extend a MarkItem class. 
	- This class contains extra values, such as the DamageSource to deal when the player takes damage or the ChatFormatting to apply when the player sends a message in chat.
	- This reduces code repetition greatly, and marks which need to alter the functionality can easily do so by overriding (this is done for the Mark of the Obliterated, which has different behavior for getDropRule).
	- This allows for other mods to more easily add their own marks (hint hint: the person making this pull request is also the one that added the Mark of the Twisted to Chromatic Arsenal as compatibility).
- Introduced the MarkHelper, which stores a list of every different mark which exists.
- The true mark no longer uses a hardcoded switch case to determine a random mark to turn into. Instead, it uses the list of marks defined in MarkHelper.
- The true mark also no longer attempts to change on the client side, resulting in a visual bug causing it to appear as if it is changing multiple times. This closes #3.

Several changes to EventHandlerMyBallsInYourMouth (and yes, that is a good event handler name. I had to make a mixin injection into it in my own mod which I promptly called MixinCBT):
- Fixed a "suspicious indentation" warning.
- colorMark's functionality has been altered. It now iterates through the mark list in MarkHelper, and applies the chat formatting of the first entry which is equipped.
	- If no marks are equipped, the message is returned unedited instead of returning null.

Changes to the lang file:
- True mark tooltip changed to reflect changes to the class.
- Appended "%1$s" to tooltip.band_of_gigantism.tooltip_strange_generic as it was missing and it was probably meant to be there.

Other changes:
- Mark of the Descended no longer uses Math.ceil on a value that is already an int.
- Mark of the Unknown now directly uses the § character instead of its Unicode escape sequence.
	- This change was also made in: LoreStatHelper, FalseHand, GoldenFryingPan, EventHandlerMyBallsInYourMouth.
- Removed a redundant "else" from MixinFoodStats. The contents of the else block are already skipped due to the return in the if statement, therefore the code in the else block can be placed outside of it.

I did not make any changes to the size-changing curios, as I do not know enough about Pehkui to do so.